### PR TITLE
Bugfix/search with invalid emoji name

### DIFF
--- a/lib/src/emoji.dart
+++ b/lib/src/emoji.dart
@@ -87,7 +87,7 @@ class Emoji {
   /// Returns Emoji by [name]
   factory Emoji.byName(String name){
     name = name.toLowerCase(); // todo: searchable name
-    return _emojis.firstWhere((Emoji emoji) => emoji.name == name);
+    return _emojis.firstWhere((Emoji emoji) => emoji.name == name, orElse: () => null);
   }
 
   /// Returns Emoji by [name] as short name.

--- a/test/emojis_test.dart
+++ b/test/emojis_test.dart
@@ -1,10 +1,16 @@
 import "package:test/test.dart";
 
+import 'package:emojis/emoji.dart';
 import 'package:emojis/emojis.dart';
 
 void main() {
   test("Emojis.directHit is 🎯", () {
     var result = "🎯";
     expect(Emojis.directHit, equals(result));
+  });
+
+  test('Search for emoji with invalid name', () {
+    final emoji = Emoji.byName('bla');
+    expect(emoji, isNull);
   });
 }


### PR DESCRIPTION
Thank you for creating this package, I am using it to find emojis by name :)

One issue I stumbled across is that if the name is invalid, then an exception will be raised.

Thus

```dart
final emoji = Emoji.byName('bla');
```

will raise the exception:

```
Bad state: No element
dart:collection                      ListMixin.firstWhere
```

This can be easily fixed by supplying an `orElse` parameter to `firstWhere`:

```dart
/// Returns Emoji by [name]
factory Emoji.byName(String name){
    name = name.toLowerCase(); // todo: searchable name
    return _emojis.firstWhere((Emoji emoji) => emoji.name == name, orElse: () => null);
}
```

You also may wish to update `byChar`, `byShortName` etc.